### PR TITLE
Fix/audit correct ips in lineage, audit ....

### DIFF
--- a/src/it/scala/com/ing/wbaa/rokku/proxy/handler/RequestHandlerS3ItTest.scala
+++ b/src/it/scala/com/ing/wbaa/rokku/proxy/handler/RequestHandlerS3ItTest.scala
@@ -4,8 +4,8 @@ import java.io.File
 
 import akka.Done
 import akka.actor.ActorSystem
+import akka.http.scaladsl.model.HttpRequest
 import akka.http.scaladsl.model.Uri.{Authority, Host}
-import akka.http.scaladsl.model.{HttpRequest, RemoteAddress}
 import com.amazonaws.auth.SignerFactory
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.{CopyObjectRequest, ObjectMetadata}
@@ -33,11 +33,11 @@ class RequestHandlerS3ItTest extends AsyncWordSpec with DiagrammedAssertions wit
   }
 
   /**
-    * Fixture for starting and stopping a test proxy that tests can interact with.
-    *
-    * @param testCode Code that accepts the created sdk
-    * @return Assertion
-    */
+   * Fixture for starting and stopping a test proxy that tests can interact with.
+   *
+   * @param testCode Code that accepts the created sdk
+   * @return Assertion
+   */
   def withS3SdkToMockProxy(testCode: AmazonS3 => Assertion): Future[Assertion] = {
     val proxy: RokkuS3Proxy = new RokkuS3Proxy with RequestHandlerS3 with SignatureProviderAws
       with FilterRecursiveListBucketHandler with MessageProviderKafka with AuditLogProvider with MemoryUserRequestQueue with RequestParser {
@@ -52,7 +52,7 @@ class RequestHandlerS3ItTest extends AsyncWordSpec with DiagrammedAssertions wit
       override def areCredentialsActive(awsRequestCredential: AwsRequestCredential)(implicit id: RequestId): Future[Option[User]] =
         Future(Some(User(UserRawJson("userId", Set("group"), "accesskey", "secretkey"))))
 
-      def createLineageFromRequest(httpRequest: HttpRequest, userSTS: User, clientIPAddress: RemoteAddress)(implicit id: RequestId): Future[Done] = Future.successful(Done)
+      def createLineageFromRequest(httpRequest: HttpRequest, userSTS: User, userIPs: UserIps)(implicit id: RequestId): Future[Done] = Future.successful(Done)
 
       override val requestPersistenceEnabled: Boolean = false
       override val configuredPersistenceId: String = "localhost-1"

--- a/src/it/scala/com/ing/wbaa/rokku/proxy/persistence/HttpRequestRecorderItTest.scala
+++ b/src/it/scala/com/ing/wbaa/rokku/proxy/persistence/HttpRequestRecorderItTest.scala
@@ -2,8 +2,8 @@ package com.ing.wbaa.rokku.proxy.persistence
 
 import akka.Done
 import akka.actor.{ActorSystem, Props}
+import akka.http.scaladsl.model.HttpRequest
 import akka.http.scaladsl.model.Uri.{Authority, Host}
-import akka.http.scaladsl.model.{HttpRequest, RemoteAddress}
 import akka.persistence.cassandra.query.scaladsl.CassandraReadJournal
 import akka.persistence.query.PersistenceQuery
 import akka.stream.ActorMaterializer
@@ -47,7 +47,7 @@ class HttpRequestRecorderItTest extends AsyncWordSpec with DiagrammedAssertions 
       override def areCredentialsActive(awsRequestCredential: AwsRequestCredential)(implicit id: RequestId): Future[Option[User]] =
         Future(Some(User(UserRawJson("userId", Set("group"), "accesskey", "secretkey"))))
 
-      def createLineageFromRequest(httpRequest: HttpRequest, userSTS: User, clientIPAddress: RemoteAddress)(implicit id: RequestId): Future[Done] = Future.successful(Done)
+      def createLineageFromRequest(httpRequest: HttpRequest, userSTS: User, userIPs: UserIps)(implicit id: RequestId): Future[Done] = Future.successful(Done)
 
       override protected def auditEnabled: Boolean = false
 

--- a/src/it/scala/com/ing/wbaa/rokku/proxy/provider/LineageProviderAtlasItTest.scala
+++ b/src/it/scala/com/ing/wbaa/rokku/proxy/provider/LineageProviderAtlasItTest.scala
@@ -7,7 +7,7 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.stream.ActorMaterializer
 import com.ing.wbaa.rokku.proxy.config.KafkaSettings
-import com.ing.wbaa.rokku.proxy.data.{AwsAccessKey, AwsSecretKey, RequestId, User, UserGroup, UserName}
+import com.ing.wbaa.rokku.proxy.data.{AwsAccessKey, AwsSecretKey, HeaderIPs, RequestId, User, UserGroup, UserIps, UserName}
 import net.manub.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig}
 import org.scalatest.{Assertion, DiagrammedAssertions, WordSpecLike}
 
@@ -31,7 +31,7 @@ class LineageProviderAtlasItTest extends WordSpecLike with DiagrammedAssertions 
     }
   }
 
-  val remoteClientIP = RemoteAddress(InetAddress.getByName("127.0.0.1"))
+  val remoteClientIP = UserIps(RemoteAddress(InetAddress.getByName("127.0.0.1")), HeaderIPs(`X-Real-IP` = Some(RemoteAddress(InetAddress.getByName("127.0.0.2")))))
 
   val userSTS = User(UserName("fakeUser"), Set.empty[UserGroup], AwsAccessKey("a"), AwsSecretKey("k"))
 

--- a/src/main/scala/com/ing/wbaa/rokku/proxy/data/HeaderIPs.scala
+++ b/src/main/scala/com/ing/wbaa/rokku/proxy/data/HeaderIPs.scala
@@ -3,17 +3,35 @@ package com.ing.wbaa.rokku.proxy.data
 import akka.http.scaladsl.model.RemoteAddress
 
 case class HeaderIPs(
-                      `X-Real-IP`: Option[RemoteAddress] = None,
-                      `X-Forwarded-For`: Option[Seq[RemoteAddress]] = None,
-                      `Remote-Address`: Option[RemoteAddress] = None) {
+    `X-Real-IP`: Option[RemoteAddress] = None,
+    `X-Forwarded-For`: Option[Seq[RemoteAddress]] = None,
+    `Remote-Address`: Option[RemoteAddress] = None) {
   def allIPs: Seq[RemoteAddress] =
     `X-Real-IP`.map(Seq(_)).getOrElse(Nil) ++
       `X-Forwarded-For`.getOrElse(Nil) ++
       `Remote-Address`.map(Seq(_)).getOrElse(Nil)
 
-  override def toString: String = {
-    List(`X-Real-IP`.map(ip => s"X-Real-IP=${ip}").getOrElse(""),
+  def toStringList: List[String] = {
+    List(
+      `X-Real-IP`.map(ip => s"X-Real-IP=$ip").getOrElse(""),
       `X-Forwarded-For`.map(ip => s"X-Forwarded-For=${ip.mkString(",")}").getOrElse(""),
-      `Remote-Address`.map(ip => s"Remote-Address=${ip}").getOrElse("")).filter(_.nonEmpty).mkString("|")
+      `Remote-Address`.map(ip => s"Remote-Address=$ip").getOrElse(""))
+      .filter(_.nonEmpty)
+  }
+}
+
+/**
+ *
+ * @param clientIp the client IP is taken from akka `Remote-Address`
+ * @param headerIps the ip from headers
+ */
+case class UserIps(clientIp: RemoteAddress, headerIps: HeaderIPs) {
+
+  def getRealIpOrClientIp: String = {
+    headerIps.`X-Real-IP`.getOrElse(clientIp).getAddress.get().getHostAddress.toString
+  }
+
+  override def toString: String = {
+    (Seq(s"ClientIp=$clientIp") ++ headerIps.toStringList).mkString("|")
   }
 }

--- a/src/main/scala/com/ing/wbaa/rokku/proxy/data/HeaderIPs.scala
+++ b/src/main/scala/com/ing/wbaa/rokku/proxy/data/HeaderIPs.scala
@@ -3,12 +3,17 @@ package com.ing.wbaa.rokku.proxy.data
 import akka.http.scaladsl.model.RemoteAddress
 
 case class HeaderIPs(
-    `X-Real-IP`: Option[RemoteAddress] = None,
-    `X-Forwarded-For`: Option[Seq[RemoteAddress]] = None,
-    `Remote-Address`: Option[RemoteAddress] = None) {
+                      `X-Real-IP`: Option[RemoteAddress] = None,
+                      `X-Forwarded-For`: Option[Seq[RemoteAddress]] = None,
+                      `Remote-Address`: Option[RemoteAddress] = None) {
   def allIPs: Seq[RemoteAddress] =
     `X-Real-IP`.map(Seq(_)).getOrElse(Nil) ++
       `X-Forwarded-For`.getOrElse(Nil) ++
       `Remote-Address`.map(Seq(_)).getOrElse(Nil)
 
+  override def toString: String = {
+    List(`X-Real-IP`.map(ip => s"X-Real-IP=${ip}").getOrElse(""),
+      `X-Forwarded-For`.map(ip => s"X-Forwarded-For=${ip.mkString(",")}").getOrElse(""),
+      `Remote-Address`.map(ip => s"Remote-Address=${ip}").getOrElse("")).filter(_.nonEmpty).mkString("|")
+  }
 }

--- a/src/main/scala/com/ing/wbaa/rokku/proxy/data/S3Request.scala
+++ b/src/main/scala/com/ing/wbaa/rokku/proxy/data/S3Request.scala
@@ -20,7 +20,9 @@ case class S3Request(
     clientIPAddress: RemoteAddress = Unknown,
     headerIPs: HeaderIPs = HeaderIPs(),
     mediaType: MediaType = MediaTypes.`text/plain`
-)
+) {
+  def userIps: UserIps = UserIps(clientIPAddress, headerIPs)
+}
 
 object S3Request extends LazyLogging {
   def extractObject(pathString: String): Option[String] =

--- a/src/main/scala/com/ing/wbaa/rokku/proxy/provider/AuditLogProvider.scala
+++ b/src/main/scala/com/ing/wbaa/rokku/proxy/provider/AuditLogProvider.scala
@@ -17,7 +17,7 @@ trait AuditLogProvider extends EventProducer with AWSMessageEventJsonSupport {
   def auditLog(s3Request: S3Request, httpRequest: HttpRequest, user: String, awsRequest: AWSRequestType, responseStatus: StatusCode)(implicit id: RequestId): Future[Done] = {
 
     if (auditEnabled) {
-      prepareAWSMessage(s3Request, httpRequest.method, user, s3Request.clientIPAddress, s3ObjectAudit(httpRequest.method.value), id, responseStatus, awsRequest)
+      prepareAWSMessage(s3Request, httpRequest.method, user, s3Request.userIps, s3ObjectAudit(httpRequest.method.value), id, responseStatus, awsRequest)
         .map(jse =>
           sendSingleMessage(jse.toString(), kafkaSettings.auditEventsTopic))
         .getOrElse(Future(Done))

--- a/src/main/scala/com/ing/wbaa/rokku/proxy/provider/AuthorizationProviderRanger.scala
+++ b/src/main/scala/com/ing/wbaa/rokku/proxy/provider/AuthorizationProviderRanger.scala
@@ -65,8 +65,9 @@ trait AuthorizationProviderRanger {
       )
 
       rangerRequest.setAction(request.accessType.auditAction)
-      //clientIp is used in audit
-      rangerRequest.setClientIPAddress(request.userIps.toString.take(200))
+      val MAX_CHARACTER_NUMBERS = 100
+      //clientIp is used in audit - we limit the log length because user can put anything in ip headers
+      rangerRequest.setClientIPAddress(request.userIps.toString.take(MAX_CHARACTER_NUMBERS))
       //RemoteIp and Forwarded are used in policies (check - AbstractIpCidrMatcher)
       rangerRequest.setRemoteIPAddress(request.clientIPAddress.toOption.map(_.getHostAddress).orNull)
       rangerRequest.setForwardedAddresses(request.headerIPs.allIPs.map(_.toOption.map(_.getHostAddress).orNull).asJava)

--- a/src/main/scala/com/ing/wbaa/rokku/proxy/provider/AuthorizationProviderRanger.scala
+++ b/src/main/scala/com/ing/wbaa/rokku/proxy/provider/AuthorizationProviderRanger.scala
@@ -65,9 +65,9 @@ trait AuthorizationProviderRanger {
       )
 
       rangerRequest.setAction(request.accessType.auditAction)
-      // We're using the original client's IP address for verification in Ranger. Ranger seems to use the
-      // RemoteIPAddress variable for this. For the header IPs we use the ForwardedAddresses: this is not
-      // completely true, but it works fairly enough.
+      //clientIp is used in audit
+      rangerRequest.setClientIPAddress(request.userIps.toString.take(200))
+      //RemoteIp and Forwarded are used in policies (check - AbstractIpCidrMatcher)
       rangerRequest.setRemoteIPAddress(request.clientIPAddress.toOption.map(_.getHostAddress).orNull)
       rangerRequest.setForwardedAddresses(request.headerIPs.allIPs.map(_.toOption.map(_.getHostAddress).orNull).asJava)
 

--- a/src/main/scala/com/ing/wbaa/rokku/proxy/provider/MessageProviderKafka.scala
+++ b/src/main/scala/com/ing/wbaa/rokku/proxy/provider/MessageProviderKafka.scala
@@ -14,13 +14,13 @@ trait MessageProviderKafka extends EventProducer with AWSMessageEventJsonSupport
   def emitEvent(s3Request: S3Request, method: HttpMethod, principalId: String, awsRequest: AWSRequestType)(implicit id: RequestId): Future[Done] =
     method match {
       case HttpMethods.POST | HttpMethods.PUT =>
-        prepareAWSMessage(s3Request, method, principalId, s3Request.clientIPAddress, s3ObjectCreated(method.value), id, StatusCodes.OK, awsRequest)
+        prepareAWSMessage(s3Request, method, principalId, s3Request.userIps, s3ObjectCreated(method.value), id, StatusCodes.OK, awsRequest)
           .map(jse =>
             sendSingleMessage(jse.toString(), kafkaSettings.createEventsTopic))
           .getOrElse(Future(Done))
 
       case HttpMethods.DELETE =>
-        prepareAWSMessage(s3Request, method, principalId, s3Request.clientIPAddress, s3ObjectRemoved(method.value), id, StatusCodes.OK, awsRequest)
+        prepareAWSMessage(s3Request, method, principalId, s3Request.userIps, s3ObjectRemoved(method.value), id, StatusCodes.OK, awsRequest)
           .map(jse =>
             sendSingleMessage(jse.toString(), kafkaSettings.deleteEventsTopic))
           .getOrElse(Future(Done))

--- a/src/main/scala/com/ing/wbaa/rokku/proxy/provider/atlas/LineageHelpers.scala
+++ b/src/main/scala/com/ing/wbaa/rokku/proxy/provider/atlas/LineageHelpers.scala
@@ -1,7 +1,7 @@
 package com.ing.wbaa.rokku.proxy.provider.atlas
 
 import akka.Done
-import akka.http.scaladsl.model.{ HttpRequest, RemoteAddress }
+import akka.http.scaladsl.model.HttpRequest
 import com.ing.wbaa.rokku.proxy.data.LineageLiterals._
 import com.ing.wbaa.rokku.proxy.data._
 import com.ing.wbaa.rokku.proxy.handler.LoggerHandlerWithId
@@ -135,12 +135,12 @@ trait LineageHelpers extends EventProducer {
       lh: LineageHeaders,
       userSTS: User,
       method: AccessType,
-      clientIPAddress: RemoteAddress,
+      userIPs: UserIps,
       externalFsPath: Option[String] = None,
       guids: LineageObjectGuids = LineageObjectGuids())(implicit id: RequestId): Future[Done] = {
 
     val userName = userSTS.userName.value
-    val clientHost = clientIPAddress.getAddress().get().getHostAddress
+    val clientHost = userIPs.getRealIpOrClientIp
     val clientType = lh.clientType.getOrElse("generic")
     val bucketObject = lh.bucketObject
     val pseudoDir = lh.pseduoDir.getOrElse(s"${lh.bucket}/")
@@ -184,12 +184,12 @@ trait LineageHelpers extends EventProducer {
       lh: LineageHeaders,
       userSTS: User,
       method: AccessType,
-      clientIPAddress: RemoteAddress,
+      userIPs: UserIps,
       srcGuids: LineageObjectGuids = LineageObjectGuids(),
       destGuids: LineageObjectGuids = LineageObjectGuids())(implicit id: RequestId): Future[Done] = {
 
     val userName = userSTS.userName.value
-    val clientHost = clientIPAddress.getAddress().get().getHostAddress
+    val clientHost = userIPs.getRealIpOrClientIp
     val clientType = lh.clientType.getOrElse("generic")
     val bucketObject = lh.bucketObject
     val pseudoDir = lh.pseduoDir.getOrElse(s"${lh.bucket}/")

--- a/src/test/scala/com/ing/wbaa/rokku/proxy/api/directive/ProxyDirectivesSpec.scala
+++ b/src/test/scala/com/ing/wbaa/rokku/proxy/api/directive/ProxyDirectivesSpec.scala
@@ -100,7 +100,7 @@ class ProxyDirectivesSpec extends WordSpec with ScalatestRouteTest with Diagramm
       def testClientIp = {
         ProxyDirectives.extracts3Request { s3Request =>
           complete(s"Client ip = ${s3Request.clientIPAddress.toOption.map(_.getHostAddress).getOrElse("unknown")}, " +
-            s"Header ips = ${s3Request.headerIPs}")
+            s"Header ips = ${s3Request.headerIPs.toString}")
         }
       }
 

--- a/src/test/scala/com/ing/wbaa/rokku/proxy/data/HeaderIPsSpec.scala
+++ b/src/test/scala/com/ing/wbaa/rokku/proxy/data/HeaderIPsSpec.scala
@@ -31,7 +31,9 @@ class HeaderIPsSpec extends WordSpec with DiagrammedAssertions {
         assert(headerIPs.allIPs.contains(address4))
       }
       "in toString method" in {
-        assert(headerIPs.toString == "X-Real-IP=1.1.1.1|X-Forwarded-For=1.1.1.2,1.1.1.3|Remote-Address=1.1.1.4")
+        assert(headerIPs.toStringList contains "X-Real-IP=1.1.1.1")
+        assert(headerIPs.toStringList contains "X-Forwarded-For=1.1.1.2,1.1.1.3")
+        assert(headerIPs.toStringList contains "Remote-Address=1.1.1.4")
       }
     }
   }

--- a/src/test/scala/com/ing/wbaa/rokku/proxy/data/HeaderIPsSpec.scala
+++ b/src/test/scala/com/ing/wbaa/rokku/proxy/data/HeaderIPsSpec.scala
@@ -30,6 +30,9 @@ class HeaderIPsSpec extends WordSpec with DiagrammedAssertions {
       "are in Remote-Address" in {
         assert(headerIPs.allIPs.contains(address4))
       }
+      "in toString method" in {
+        assert(headerIPs.toString == "X-Real-IP=1.1.1.1|X-Forwarded-For=1.1.1.2,1.1.1.3|Remote-Address=1.1.1.4")
+      }
     }
   }
 }


### PR DESCRIPTION
In lineage the server entity get ip from the header x-real-ip (set by haproxy) or if not present from akka RemoteAddress 

For the rest places we set all ips from headers - e.g:
`ClientIp=5.5.5.5|X-Real-IP=3.3.3.3|X-Forwarded-For=1.1.1.1|Remote-Address=2.2.2.2`