### PR TITLE
add status code to error/warn logs

### DIFF
--- a/src/main/scala/com/ing/wbaa/rokku/proxy/handler/LoggerHandlerWithId.scala
+++ b/src/main/scala/com/ing/wbaa/rokku/proxy/handler/LoggerHandlerWithId.scala
@@ -1,5 +1,6 @@
 package com.ing.wbaa.rokku.proxy.handler
 
+import akka.http.scaladsl.model.{ StatusCode, StatusCodes }
 import com.ing.wbaa.rokku.proxy.data.RequestId
 import com.typesafe.scalalogging.Logger
 import org.slf4j.{ LoggerFactory, MDC }
@@ -11,6 +12,7 @@ class LoggerHandlerWithId {
     Logger(LoggerFactory.getLogger(getClass.getName))
 
   private val requestIdKey = "request.id"
+  private val statusCodeKey = "request.statusCode"
 
   def debug(message: String, args: Any*)(implicit id: RequestId): Unit = {
     MDC.put(requestIdKey, id.value)
@@ -24,16 +26,19 @@ class LoggerHandlerWithId {
     MDC.remove(requestIdKey)
   }
 
-  def warn(message: String, args: Any*)(implicit id: RequestId): Unit = {
+  def warn(message: String, args: Any*)(implicit id: RequestId, statusCode: StatusCode = StatusCodes.Continue): Unit = {
     MDC.put(requestIdKey, id.value)
+    MDC.put(statusCodeKey, statusCode.value)
     log.warn(message, args)
     MDC.remove(requestIdKey)
+    MDC.remove(statusCodeKey)
   }
 
-  def error(message: String, args: Any*)(implicit id: RequestId): Unit = {
+  def error(message: String, args: Any*)(implicit id: RequestId, statusCode: StatusCode = StatusCodes.Continue): Unit = {
     MDC.put(requestIdKey, id.value)
+    MDC.put(statusCodeKey, statusCode.value)
     log.error(message, args)
     MDC.remove(requestIdKey)
+    MDC.remove(statusCodeKey)
   }
-
 }

--- a/src/main/scala/com/ing/wbaa/rokku/proxy/handler/RequestHandlerS3.scala
+++ b/src/main/scala/com/ing/wbaa/rokku/proxy/handler/RequestHandlerS3.scala
@@ -75,7 +75,8 @@ trait RequestHandlerS3 extends RadosGatewayHandler with S3Client with UserReques
       if (addIfAllowedUserToRequestQueue(user)) {
         fireRequestToS3(request).andThen { case _ => decrement(user) }
       } else {
-        logger.info("user {} is sending too many requests", user.userName.value)
+        implicit val returnStatusCode: StatusCodes.ServerError = StatusCodes.ServiceUnavailable
+        logger.warn("user {} is sending too many requests", user.userName.value)
         Future.failed(new RokkuThrottlingException("Throttling"))
       }
     } else {


### PR DESCRIPTION
add a separate `request.statusCode` field to warn/error logs to easily find logs with response 5XX