### PR TITLE
revert akka http from 10.1.10 to 10.1.9

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ scalacOptions += "-Xfatal-warnings"
 // Experimental: improved update resolution.
 updateOptions := updateOptions.value.withCachedResolution(cachedResoluton = true)
 
-val akkaHttpVersion = "10.1.10"
+val akkaHttpVersion = "10.1.9"
 val akkaVersion = "2.5.25"
 val logbackJson = "0.1.5"
 val metricVersion = "3.2.2" // align with C* driver core, can be updated with new C* persistence from akka


### PR DESCRIPTION
we have a problem with a queue and in the log there are:
`[0 (Unconnected)] Slot execution failed. That's probably a bug. Please file a bug at https://github.com/akka/akka-http/issues. Slot is restarted.`