### PR TITLE
Allow browser to pass ETag header to script

### DIFF
--- a/src/main/scala/com/ing/wbaa/rokku/proxy/api/directive/ProxyDirectives.scala
+++ b/src/main/scala/com/ing/wbaa/rokku/proxy/api/directive/ProxyDirectives.scala
@@ -188,6 +188,7 @@ object ProxyDirectives extends LazyLogging {
           Seq(
             `Access-Control-Allow-Origin`.*,
             RawHeader("Access-Control-Allow-Methods", "*"),
+            RawHeader("Access-Control-Expose-Headers", "ETag"),
             RawHeader("Access-Control-Allow-Headers", "*")) ++ oldHeaders
         }
       } else {


### PR DESCRIPTION
Fix CORS configuration to allow browser to pass `ETag` to script for it to then create valid XML in `CompleteMultipartUpload` request