### PR TITLE
Remove x-amz-security-token header 

### DIFF
--- a/src/main/scala/com/ing/wbaa/rokku/proxy/handler/RequestHandlerS3.scala
+++ b/src/main/scala/com/ing/wbaa/rokku/proxy/handler/RequestHandlerS3.scala
@@ -46,6 +46,7 @@ trait RequestHandlerS3 extends S3Client with UserRequestQueue {
       .withEntity(originalRequest.entity)
       .addHeader(RawHeader("User-Agent", userAgent))
       .removeHeader("Authorization")
+      .removeHeader("x-amz-security-token")
       .addHeader(RawHeader("Authorization", npaRequest.getHeaders.get("Authorization")))
 
     fireRequestToS3(newRequest, userSTS).flatMap { response =>


### PR DESCRIPTION
Remove x-amz-security-token which is being proxied to the underlying storage. This causes problems when integrating with Minio S3.